### PR TITLE
Add toggleable system audio when stream is running and disable mic share after a stream has started  @axbg

### DIFF
--- a/clients/share/index.html
+++ b/clients/share/index.html
@@ -66,8 +66,9 @@
     <div id="audio-container">
       <input type="checkbox" name="captureSystem" onchange="toggleAudio(event, 'system')" />
       <label for="captureAudio">System audio</label>
-      <input type="checkbox" name="captureMic" onchange="toggleAudio(event, 'mic')" />
-      <label for="captureAudio">Microphone audio</label>
+      <input type="checkbox" name="captureMic" id="captureMic" onchange="toggleAudio(event, 'mic')"
+        title="Microphone cannot be enabled after a stream has started" />
+      <label for="captureAudio" title="Microphone cannot be enabled after a stream has started">Microphone audio</label>
     </div>
     <p>Configurations</p>
     <div id="configurations-container">

--- a/clients/share/share.js
+++ b/clients/share/share.js
@@ -75,11 +75,15 @@ function loadConfig() {
 async function toggleAudio(event, type) {
   if (type === "system") {
     captureSystemAudio = event.target.checked;
-    if (captureStream && captureStream.getAudioTracks().length > 0) {
+    if (!!captureStream && captureStream.getAudioTracks().length > 0) {
       captureStream.getAudioTracks()[0].enabled = captureSystemAudio;
     }
   } else if (type === "mic") {
     captureMic = event.target.checked;
+
+    if (!!captureMicStream && captureMicStream.getAudioTracks().length > 0) {
+      captureMicStream.getAudioTracks()[0].enabled = captureMic;
+    }
   }
 }
 
@@ -175,6 +179,8 @@ async function startShare() {
     if (!captureMicStream) {
       return;
     }
+  } else {
+    document.getElementById("captureMic").disabled = true;
   }
 
   toggleButton("share", false);
@@ -284,5 +290,11 @@ function stopShare() {
     captureMicStream.getTracks().forEach(track => track.stop());
   }
 
+  captureStream = null;
+  captureMicStream = null;
+
+  viewers = 0;
+  updateViewers(false);
   document.getElementById("video").srcObject = null;
+  document.getElementById("captureMic").disabled = false;
 }

--- a/clients/share/share.js
+++ b/clients/share/share.js
@@ -75,6 +75,9 @@ function loadConfig() {
 async function toggleAudio(event, type) {
   if (type === "system") {
     captureSystemAudio = event.target.checked;
+    if (captureStream && captureStream.getAudioTracks().length > 0) {
+      captureStream.getAudioTracks()[0].enabled = captureSystemAudio;
+    }
   } else if (type === "mic") {
     captureMic = event.target.checked;
   }
@@ -135,7 +138,11 @@ function handleChannelName(event) {
 
 async function startCapture() {
   try {
-    captureStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: captureSystemAudio ? { supressLocalAudioPlayback: true } : false });
+    captureStream = await navigator.mediaDevices.getDisplayMedia({ video: true, audio: { supressLocalAudioPlayback: true } });
+
+    if (captureStream.getAudioTracks().length > 0) {
+      captureStream.getAudioTracks()[0].enabled = captureSystemAudio;
+    }
   } catch (err) {
     console.error(`Error: ${err}`);
   }


### PR DESCRIPTION
Adding a new track after a stream has started requires renegotiation between the sharer and viewers, which would be an overkill for now. 

The system audio can be enabled or disabled even after a stream has started, but the microphone capture should be enabled before. 

If the microphone capture was enabled before the stream started, the sharer can toggle it during streaming. 